### PR TITLE
fix: GH Action to push container images on GH registry

### DIFF
--- a/.github/workflows/api-merge.yml
+++ b/.github/workflows/api-merge.yml
@@ -6,7 +6,7 @@ on:
       - 'api/**/*'
 
 jobs:
-  test:
+  merge:
     runs-on: ubuntu-latest
     services:
       docker:
@@ -23,11 +23,15 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
-      - run: mvn --batch-mode --update-snapshots -Ddevelocity.scan.termsOfUse.url=https://gradle.com/help/legal-terms-of-use -Ddevelocity.scan.termsOfUse.accept=true -Dscan.tag.backend-engineer -Dquarkus.container-image.registry=ghcr.io -Dquarkus.container-image.push=true -Dquarkus.container-image.build=true -Dquarkus.container-image.group=davidesalerno package
+      - name: Log in to registry
+      # This is where you will update the PAT to GITHUB_TOKEN
+        run: echo "${{ secrets.DS_GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - run: mvn --batch-mode --update-snapshots -Ddevelocity.scan.termsOfUse.url=https://gradle.com/help/legal-terms-of-use -Ddevelocity.scan.termsOfUse.accept=true -Dscan.tag.backend-engineer -Dquarkus.container-image.registry=ghcr.io -Dquarkus.container-image.push=true -Dquarkus.container-image.build=true -Dquarkus.container-image.group=davidesalerno -Dquarkus.container-image.username=${{ github.actor }} -Dquarkus.container-image.password=${{ secrets.DS_GITHUB_TOKEN }}  package
       - run: mkdir staging && cp **/target/*.jar staging
       - uses: actions/upload-artifact@v4
         with:
           name: Package
           path: ./api/staging
         env:
-          GITHUB_TOKEN: ${{ secrets.DS_GITHUB_TOKEN }}
+          GHR_USR: ${{github.actor}}
+          GHR_PWD: ${{ secrets.DS_GITHUB_TOKEN }}

--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -6,9 +6,11 @@ on:
       - 'main'
     paths:
       - 'api/**/*'
+      - '.github/**/*'
   pull_request:
     paths:
       - 'api/**/*'
+      - '.github/**/*'
 
 jobs:
   test:


### PR DESCRIPTION
<!--

Welcome to Condoman project! Before contributing, make sure to:

- Rebase your branch on the latest upstream main
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concise and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist 

-->

**Description of the change:**

Fixing GitHub Action for API services

**Motivation for the change:**

Fixing GitHub Action for API services

**Checklist**

- [x] Add or Modify a unit test for your change
- [x] Have you verified that tall the tests are passing?

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>****